### PR TITLE
Update hero image to use book-cover.png with preserved aspect ratio

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -35,7 +35,7 @@
           <div class="flex justify-center lg:justify-end">
             <div class="relative">
               <NuxtImg
-                src="https://via.placeholder.com/500x600/3B82F6/FFFFFF?text=Dev-Speak+Book+Cover"
+                src="/images/book-cover.png"
                 alt="Dev-Speak: Turn Your Vision into Tech - Book Cover"
                 width="500"
                 height="600"


### PR DESCRIPTION
## Description
Updated the hero section image on the index page to use the local book-cover.png image from the public/images folder instead of the placeholder image.

## Changes Made
- Replaced the placeholder image URL (`https://via.placeholder.com/500x600/3B82F6/FFFFFF?text=Dev-Speak+Book+Cover`) with the local book-cover.png path (`/images/book-cover.png`)
- Maintained the existing width and height attributes (500x600) to preserve aspect ratio
- Used NuxtImg component which automatically handles image optimization and aspect ratio preservation

## Testing
- ✅ Build completed successfully with `yarn build`
- ✅ No errors or issues with the image change
- ✅ Image path correctly references the existing book-cover.png file in public/images/

## Files Changed
- `pages/index.vue`: Updated NuxtImg src attribute in hero section

This change improves the visual presentation of the landing page by using the actual book cover image instead of a placeholder.