### PR TITLE
Fix aspect ratio on book-cover.png image

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -37,7 +37,7 @@
               <NuxtImg
                 src="/images/book-cover.png"
                 alt="Dev-Speak: Turn Your Vision into Tech - Book Cover"
-                width="500"
+                width="400"
                 height="600"
                 class="rounded-lg shadow-2xl transform hover:scale-105 transition-transform duration-300"
                 loading="eager"


### PR DESCRIPTION
## Description
Fixed the aspect ratio issue with the book-cover.png image on the homepage hero section.

## Changes Made
- Updated NuxtImg component width from 500px to 400px to match the natural 2:3 aspect ratio
- The image file dimensions are 1024x1536 (2:3 ratio) but was being displayed as 500x600 (5:6 ratio)
- Now displays correctly without distortion using 400x600 (2:3 ratio)

## Testing
- Built the project successfully with `yarn build`
- No build errors or warnings related to the image changes
- Aspect ratio now matches the natural image proportions

## Impact
- Improves visual presentation of the book cover on the homepage
- Eliminates image distortion that was occurring due to aspect ratio mismatch
- Maintains responsive design and existing styling