### PR TITLE
Fix blog index.vue content collection schema

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -5,11 +5,20 @@ export default defineContentConfig({
         blog: defineCollection({
             type: 'page',
             source: 'blog/*.md',
-            // Define custom schema for docs collection
+            // Define custom schema for blog collection
             schema: z.object({
-                tags: z.array(z.string()),
-                image: z.string(),
-                date: z.date()
+                title: z.string(),
+                slug: z.string().optional(),
+                date: z.date(),
+                draft: z.boolean().optional(),
+                tags: z.array(z.string()).optional(),
+                image: z.string().optional(),
+                author: z.object({
+                    display_name: z.string()
+                }).optional(),
+                top: z.boolean().optional(),
+                description: z.string().optional(),
+                excerpt: z.string().optional()
             })
         })
     }


### PR DESCRIPTION
## Summary

This PR fixes the blog index.vue so it can properly read blog posts from the blog content collection.

## Problem

The blog index.vue was unable to display blog posts due to a schema mismatch between the content.config.ts definition and the actual blog post frontmatter structure.

## Solution

- Updated content.config.ts to include all fields present in existing blog posts
- Made `tags` and `image` fields optional to match current blog post structure  
- Added support for `title`, `slug`, `draft`, `author`, `top`, `description`, and `excerpt` fields
- Maintained required `date` field for proper sorting and display

## Changes Made

- Modified `content.config.ts` to define a comprehensive and flexible schema for blog posts
- All existing blog posts now conform to the schema without requiring changes
- The blog index.vue can now properly load and display blog posts from the content collection

## Testing

- ✅ Build completes successfully with no content-related errors
- ✅ @nuxt/content processes blog collection and files correctly
- ✅ Schema validation passes for existing blog posts

## Impact

- Blog posts are now properly loaded and displayed on the blog index page
- Future blog posts can use any combination of the defined optional fields
- Maintains backward compatibility with existing blog post structure